### PR TITLE
use xdg directories

### DIFF
--- a/blinky/utils.py
+++ b/blinky/utils.py
@@ -129,3 +129,15 @@ def getchar(msg):
 		termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 	print()
 	return ch
+
+
+def default_blinky_dir():
+	from xdg import BaseDirectory
+	# load_data_paths (generator) is empty if no data dirs exist
+	# so we can fall back to checking ~/.blinky
+	for xdg_dir in BaseDirectory.load_data_paths('blinky'):
+		return xdg_dir
+	# if the user does not have an existing ~/.blinky dir, start using the XDG default
+	if os.path.isdir('~/.blinky'):  # backward compatibility
+		return '~/.blinky'
+	return BaseDirectory.save_data_path('blinky')

--- a/blinky/utils.py
+++ b/blinky/utils.py
@@ -131,7 +131,7 @@ def getchar(msg):
 	return ch
 
 
-def default_blinky_dir():
+def default_data_dir():
 	from xdg import BaseDirectory
 	# load_data_paths (generator) is empty if no data dirs exist
 	# so we can fall back to checking ~/.blinky

--- a/blinky/utils.py
+++ b/blinky/utils.py
@@ -131,13 +131,21 @@ def getchar(msg):
 	return ch
 
 
-def default_data_dir():
+def get_data_dir():
 	from xdg import BaseDirectory
-	# load_data_paths (generator) is empty if no data dirs exist
-	# so we can fall back to checking ~/.blinky
-	for xdg_dir in BaseDirectory.load_data_paths('blinky'):
-		return xdg_dir
-	# if the user does not have an existing ~/.blinky dir, start using the XDG default
+
 	if os.path.isdir('~/.blinky'):  # backward compatibility
-		return '~/.blinky'
+		print(" DEPRECATION WARNING: support for ~/.blinky will be removed in future versions, call migrate-blinky-dirs.py to migrate and silence this message")
+		return '~/.blinky/cache'
+
 	return BaseDirectory.save_data_path('blinky')
+
+
+def get_cache_dir():
+	from xdg import BaseDirectory
+
+	if os.path.isdir(os.path.abspath('~/.blinky')):  # backward compatibility
+		print(" DEPRECATION WARNING: support for ~/.blinky will be removed in future versions, call migrate-blinky-dirs.py to migrate and silence this message")
+		return '~/.blinky/cache'
+
+	return BaseDirectory.save_cache_path('blinky')

--- a/scripts/blinky
+++ b/scripts/blinky
@@ -19,7 +19,7 @@ primary.add_argument("-Scc", action='store_true', default=False, dest='fullclean
 parser.add_argument("--asdeps", action='store_true', default=False, dest='asdeps', help="If packages are installed, install them as dependencies")
 parser.add_argument("--force-review", action='store_true', default=False, dest='force_review', help="Force review even if exact copies of the files have already been reviewed positively")
 parser.add_argument("--keep-builddeps", action='store_true', default=False, dest='keep_builddeps', help="Do not uninstall previously uninstalled makedeps after building")
-parser.add_argument("--keep-sources", action='store', default='none', dest='keep_sources', help="Keep sources, can be 'none' (default), 'skipped', for keeping skipped packages only, or 'all'")
+parser.add_argument("--keep-sources", action='store', default='none', dest='keep_sources', metavar='<value>', help="Keep sources, can be 'none' (default), 'skipped', for keeping skipped packages only, or 'all'")
 parser.add_argument("--build-only", action='store_true', default=False, dest='buildonly', help="Only build, do not install anything")
 parser.add_argument("pkg_candidates", metavar="pkgname", type=str, nargs="*", help="packages to install/build")
 parser.add_argument('--verbose', '-v', action='count', default=0, dest='verbosity')

--- a/scripts/blinky
+++ b/scripts/blinky
@@ -19,7 +19,6 @@ primary.add_argument("-Scc", action='store_true', default=False, dest='fullclean
 parser.add_argument("--asdeps", action='store_true', default=False, dest='asdeps', help="If packages are installed, install them as dependencies")
 parser.add_argument("--force-review", action='store_true', default=False, dest='force_review', help="Force review even if exact copies of the files have already been reviewed positively")
 parser.add_argument("--keep-builddeps", action='store_true', default=False, dest='keep_builddeps', help="Do not uninstall previously uninstalled makedeps after building")
-parser.add_argument("--local-path", action='store', default=utils.default_data_dir(), dest='aur_local', help="Local path for building and cache")
 parser.add_argument("--keep-sources", action='store', default='none', dest='keep_sources', help="Keep sources, can be 'none' (default), 'skipped', for keeping skipped packages only, or 'all'")
 parser.add_argument("--build-only", action='store_true', default=False, dest='buildonly', help="Only build, do not install anything")
 parser.add_argument("pkg_candidates", metavar="pkgname", type=str, nargs="*", help="packages to install/build")
@@ -31,9 +30,6 @@ args = parser.parse_args()
 
 Config = namedtuple('Context', ['cachedir', 'builddir', 'revieweddir', 'logdir', 'force_review', 'rebuild', 'difftool', 'makepkgconf', 'v'])
 
-# process arguments if necessary
-args.aur_local = os.path.abspath(os.path.expanduser(args.aur_local))
-
 verified_makepkgconf = '/etc/makepkg.conf'
 if os.path.isfile(args.makepkgconf) and os.access(args.makepkgconf, os.R_OK):
 	verified_makepkgconf = args.makepkgconf
@@ -41,10 +37,10 @@ else:
 	utils.logerr(None, "{} not found, using /etc/makepkg.conf instead".format(args.makepkgconf))
 
 ctx = Config(
-		cachedir=os.path.join(args.aur_local, 'cache'),
-		builddir=os.path.join(args.aur_local, 'build'),
-		logdir=os.path.join(args.aur_local, 'logs'),
-		revieweddir=os.path.join(args.aur_local, 'reviewed'),
+		cachedir=os.path.join(util.get_cache_dir, 'pkg'),
+		builddir=os.path.join(util.get_cache_dir, 'build'),
+		logdir=os.path.join(util.get_cache_dir, 'logs'),
+		revieweddir=os.path.join(util.get_data_dir, 'reviewed'),
 		force_review=args.force_review,
 		rebuild='package' if args.rebuildpkg else 'tree' if args.rebuildtree else None,
 		difftool=args.difftool,

--- a/scripts/blinky
+++ b/scripts/blinky
@@ -19,7 +19,7 @@ primary.add_argument("-Scc", action='store_true', default=False, dest='fullclean
 parser.add_argument("--asdeps", action='store_true', default=False, dest='asdeps', help="If packages are installed, install them as dependencies")
 parser.add_argument("--force-review", action='store_true', default=False, dest='force_review', help="Force review even if exact copies of the files have already been reviewed positively")
 parser.add_argument("--keep-builddeps", action='store_true', default=False, dest='keep_builddeps', help="Do not uninstall previously uninstalled makedeps after building")
-parser.add_argument("--local-path", action='store', default='~/.blinky', dest='aur_local', help="Local path for building and cache")
+parser.add_argument("--local-path", action='store', default=None, dest='aur_local', help="Local path for building and cache")
 parser.add_argument("--keep-sources", action='store', default='none', dest='keep_sources', help="Keep sources, can be 'none' (default), 'skipped', for keeping skipped packages only, or 'all'")
 parser.add_argument("--build-only", action='store_true', default=False, dest='buildonly', help="Only build, do not install anything")
 parser.add_argument("pkg_candidates", metavar="pkgname", type=str, nargs="*", help="packages to install/build")
@@ -28,6 +28,8 @@ parser.add_argument("--difftool", action='store', default=None, dest='difftool',
 parser.add_argument("--makepkg.conf", action='store', default='/etc/makepkg.conf', dest='makepkgconf', help="Configuration file for makepkg, defaults to /etc/makepkg.conf")
 
 args = parser.parse_args()
+if args.aur_local is None:
+	args.aur_local = utils.default_blinky_dir()
 
 Config = namedtuple('Context', ['cachedir', 'builddir', 'revieweddir', 'logdir', 'force_review', 'rebuild', 'difftool', 'makepkgconf', 'v'])
 

--- a/scripts/blinky
+++ b/scripts/blinky
@@ -19,7 +19,7 @@ primary.add_argument("-Scc", action='store_true', default=False, dest='fullclean
 parser.add_argument("--asdeps", action='store_true', default=False, dest='asdeps', help="If packages are installed, install them as dependencies")
 parser.add_argument("--force-review", action='store_true', default=False, dest='force_review', help="Force review even if exact copies of the files have already been reviewed positively")
 parser.add_argument("--keep-builddeps", action='store_true', default=False, dest='keep_builddeps', help="Do not uninstall previously uninstalled makedeps after building")
-parser.add_argument("--local-path", action='store', default=None, dest='aur_local', help="Local path for building and cache")
+parser.add_argument("--local-path", action='store', default=utils.default_data_dir(), dest='aur_local', help="Local path for building and cache")
 parser.add_argument("--keep-sources", action='store', default='none', dest='keep_sources', help="Keep sources, can be 'none' (default), 'skipped', for keeping skipped packages only, or 'all'")
 parser.add_argument("--build-only", action='store_true', default=False, dest='buildonly', help="Only build, do not install anything")
 parser.add_argument("pkg_candidates", metavar="pkgname", type=str, nargs="*", help="packages to install/build")
@@ -28,8 +28,6 @@ parser.add_argument("--difftool", action='store', default=None, dest='difftool',
 parser.add_argument("--makepkg.conf", action='store', default='/etc/makepkg.conf', dest='makepkgconf', help="Configuration file for makepkg, defaults to /etc/makepkg.conf")
 
 args = parser.parse_args()
-if args.aur_local is None:
-	args.aur_local = utils.default_blinky_dir()
 
 Config = namedtuple('Context', ['cachedir', 'builddir', 'revieweddir', 'logdir', 'force_review', 'rebuild', 'difftool', 'makepkgconf', 'v'])
 

--- a/scripts/migrate-blinky-dirs.py
+++ b/scripts/migrate-blinky-dirs.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from xdg import BaseDirectory
+import os, shutil
+
+data  = BaseDirectory.save_data_path('blinky')
+cache = BaseDirectory.save_cache_path('blinky')
+blinkydir = os.path.abspath(os.path.expanduser('~/.blinky'))
+
+if not os.path.isdir(blinkydir):  # backward compatibility
+	print("No ~/.blinky found, nothing to migrate")
+	exit()
+
+def migrate(src, target, execute=False):
+	if not execute:
+		print("Moving ~/blinky/{} to {}".format(src, target))
+	else:
+		src = os.path.join(blinkydir, src)
+		shutil.move(src, target)
+
+print("Gonna start migrating ~/.blinky:")
+migrate("build", cache)
+migrate("logs", cache)
+migrate("cache", os.path.join(cache, 'pkg'))
+
+input("Proceed? (Ctrl+C if not)")
+
+migrate("build", cache, execute=True)
+migrate("logs", cache, execute=True)
+migrate("cache", os.path.join(cache, 'pkg'), execute=True)
+
+shutil.rmtree(blinkydir)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     install_requires=[
         #'pyalpm'  # not on pypi
 		#'colordiff'  # not on pypi
+        'pyxdg',
         'requests',
         'termcolor'
     ],


### PR DESCRIPTION
draft for #11, just to put it out there.

Note: at the moment I'm doing lazy evaluation. If the user specifies a local_aur directory, `default_blinky_dir` is not called. I doubt the benefit (runtime performance, not importing/not relying on xdg being installed) is worth the spaghetti code in scripts/blinky.

I did not (yet) split data/cache (didn't see any config to split further).

EDIT: oh, and this is void of any transition strategy for users from `~/.blinky` to `$XDG…`