### PR TITLE
drop unused command line argument

### DIFF
--- a/scripts/blinky
+++ b/scripts/blinky
@@ -19,7 +19,6 @@ primary.add_argument("-Scc", action='store_true', default=False, dest='fullclean
 parser.add_argument("--asdeps", action='store_true', default=False, dest='asdeps', help="If packages are installed, install them as dependencies")
 parser.add_argument("--force-review", action='store_true', default=False, dest='force_review', help="Force review even if exact copies of the files have already been reviewed positively")
 parser.add_argument("--keep-builddeps", action='store_true', default=False, dest='keep_builddeps', help="Do not uninstall previously uninstalled makedeps after building")
-parser.add_argument("--local-path", action='store', default='~/.blinky', dest='aur_local', metavar='<path>', help="Local path for building and cache")
 parser.add_argument("--keep-sources", action='store', default='none', dest='keep_sources', metavar='<value>', help="Keep sources, can be 'none' (default), 'skipped', for keeping skipped packages only, or 'all'")
 parser.add_argument("--build-only", action='store_true', default=False, dest='buildonly', help="Only build, do not install anything")
 parser.add_argument("pkg_candidates", metavar="pkgname", type=str, nargs="*", help="packages to install/build")
@@ -31,9 +30,6 @@ parser.add_argument("--ignore", action='append', default=[], dest='ignored_pkgs'
 args = parser.parse_args()
 
 Config = namedtuple('Context', ['cachedir', 'builddir', 'revieweddir', 'logdir', 'force_review', 'rebuild', 'difftool', 'makepkgconf', 'ignored_pkgs', 'v'])
-
-# process arguments if necessary
-args.aur_local = os.path.abspath(os.path.expanduser(args.aur_local))
 
 verified_makepkgconf = '/etc/makepkg.conf'
 if os.path.isfile(args.makepkgconf) and os.access(args.makepkgconf, os.R_OK):


### PR DESCRIPTION
istm when switching to xdg directories, the local-path cli argument didn't get dropped but became unused.