### PR TITLE
Add reviewed pkgbuild files to migration script

### DIFF
--- a/scripts/migrate-blinky-dirs.py
+++ b/scripts/migrate-blinky-dirs.py
@@ -22,11 +22,17 @@ print("Gonna start migrating ~/.blinky:")
 migrate("build", cache)
 migrate("logs", cache)
 migrate("cache", os.path.join(cache, 'pkg'))
+migrate("reviewed", data)
 
 input("Proceed? (Ctrl+C if not)")
 
 migrate("build", cache, execute=True)
 migrate("logs", cache, execute=True)
 migrate("cache", os.path.join(cache, 'pkg'), execute=True)
+migrate("reviewed", data, execute=True)
 
-shutil.rmtree(blinkydir)
+try:
+    os.rmdir(blinkydir)
+except OSError:
+    print("There appear to be unmigrated files left in ~/.blinky.")
+    print("Please check if this is an error of the migration script.")


### PR DESCRIPTION
This fixes #17. As suggested by @cherti, I used `rmdir` as a safetynet against unmigrated files.