### PR TITLE
switch distutils to setuptools

### DIFF
--- a/blinky/pacman.py
+++ b/blinky/pacman.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import subprocess, os, pyalpm, pycman
-from distutils import spawn
+from shutil import which
 from threading import Lock
 
 handle = pycman.config.init_with_config('/etc/pacman.conf') #pyalpm.Handle("/", "/var/lib/pacman")
@@ -9,7 +9,7 @@ ldb_lock, ldb = Lock(), handle.get_localdb()
 sdbs = [(Lock(), sdb) for sdb in handle.get_syncdbs()]
 
 devnull = open(os.devnull, 'w')
-sudo = spawn.find_executable("sudo")
+sudo = which("sudo")
 
 def refresh():
 	global handle, ldb, sdbs

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='blinky',


### PR DESCRIPTION
distutils is/will be deprecated.
As per [PEP 632](https://peps.python.org/pep-0632/) that's the recommended migration path.